### PR TITLE
FormItem: field name support dot in prop

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -46,14 +46,14 @@ export function getPropByPath(obj, path, strict) {
   // remove start dot in path
   path = path.replace(/^\./, '');
   // replace .=>[]
-  path = path.replace(/\.(\w+)((?:\.)|\[)/g, '[$1]$2');
+  path = path.replace(/\.(\w+)((?:\.)|\[|$)/g, '[$1]$2');
   // replace start key
   path = path.replace(/^(\w+)/, '[$1]');
 
   // sometime path is empty when init, so match will get null
   let keyArr = path.match(/(?:\[)(.*?)(?:\])/g) || [];
-  // remove [] in key
-  keyArr = keyArr.map((k) => k.replace(/(\[|\])/g, ''));
+  // remove [|]|"|' in key
+  keyArr = keyArr.map((k) => k.replace(/(\[|\]|"|')/g, ''));
   let i = 0;
   for (let len = keyArr.length; i < len - 1; ++i) {
     if (!tempObj && !strict) break;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -43,10 +43,17 @@ export const getValueByPath = function(object, prop) {
 
 export function getPropByPath(obj, path, strict) {
   let tempObj = obj;
-  path = path.replace(/\[(\w+)\]/g, '.$1');
+  // remove start dot in path
   path = path.replace(/^\./, '');
+  // replace .=>[]
+  path = path.replace(/\.(\w+)((?:\.)|\[)/g, '[$1]$2');
+  // replace start key
+  path = path.replace(/^(\w+)/, '[$1]');
 
-  let keyArr = path.split('.');
+  // sometime path is empty when init, so match will get null
+  let keyArr = path.match(/(?:\[)(.*?)(?:\])/g) || [];
+  // remove [] in key
+  keyArr = keyArr.map((k) => k.replace(/(\[|\])/g, ''));
   let i = 0;
   for (let len = keyArr.length; i < len - 1; ++i) {
     if (!tempObj && !strict) break;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

### description
Sometimes property name has `.` in form object, so need support to parse this key in form.

### example
```html
<el-form :model="wifi">
  <el-form-item prop="bands['2.4g'].channel"></el-form-item>
</el-form>
```
```js
rules: {
  "bands['2.4g'].channel": [{
     // validators
  }]
},
wifi: {
  bands: {
    "2.4g": {
        channel: 11
    },
    "5g": {
        channel: 40
    }
  }
}
```
### related issues
#10299
